### PR TITLE
Feat/issue 7 인터랙션 마커 만들기

### DIFF
--- a/components/atoms/MapComp/mapBoxGl.tsx
+++ b/components/atoms/MapComp/mapBoxGl.tsx
@@ -86,12 +86,16 @@ const MapComp = ({ markerList = [], placeListGeoJson = [] }: MapCompProps) => {
           for (const feature of allFeatures) {
             const coords = feature.geometry.coordinates;
             const props = feature.properties;
-            const { id, instaId, borderColor } = props;
+            const { id, instaId, borderColor, placeName } = props;
             if (!allPointMarkers[id]) {
               // const src = `/images/${instaId}/0.jpg`;
               const el = document.createElement("div");
               const marker = document.createElement("div");
-              marker.innerHTML = PointMarkerString({ instaId, borderColor });
+              marker.innerHTML = PointMarkerString({
+                instaId,
+                borderColor,
+                placeName,
+              });
               el.appendChild(marker);
               AddPointMarkerEvents(el);
               allPointMarkers[id] = new mapboxgl.Marker({

--- a/components/atoms/MapComp/mapBoxGl.tsx
+++ b/components/atoms/MapComp/mapBoxGl.tsx
@@ -89,17 +89,18 @@ const MapComp = ({ markerList = [], placeListGeoJson = [] }: MapCompProps) => {
             const { id, instaId, borderColor, placeName } = props;
             if (!allPointMarkers[id]) {
               // const src = `/images/${instaId}/0.jpg`;
+              // const el = document.createElement("div");
               const el = document.createElement("div");
-              const marker = document.createElement("div");
-              marker.innerHTML = PointMarkerString({
+              el.innerHTML = PointMarkerString({
                 instaId,
                 borderColor,
                 placeName,
               });
-              el.appendChild(marker);
+              // el.appendChild(marker);
               AddPointMarkerEvents(el);
               allPointMarkers[id] = new mapboxgl.Marker({
                 element: el,
+                anchor: "bottom",
               }).setLngLat(coords);
             }
             if (!allClusterMarkers[id]) {

--- a/components/atoms/Marker/ClusterMarker/addClusterMarkerEvents.ts
+++ b/components/atoms/Marker/ClusterMarker/addClusterMarkerEvents.ts
@@ -21,7 +21,6 @@ function mouseOverListenerFunction(this: HTMLElement, e: Event) {
   };
   
 
-  console.log(child.children);
   for (let i = 0; i < child.children.length; i++) {
     let leaf = child.children[i]
     leaf.classList.add('cl-active')

--- a/components/atoms/Marker/ClusterMarker/cluster.module.css
+++ b/components/atoms/Marker/ClusterMarker/cluster.module.css
@@ -5,7 +5,7 @@
     animation : pop 0.3s ease-in-out;
     }
 .mouseOut{
-    z-index:1;
+    z-index:none;
     transform-origin: 50% 50% 0;
     transform:scale(1);
     transition:0.2s ease;

--- a/components/atoms/Marker/PointMarker/index.tsx
+++ b/components/atoms/Marker/PointMarker/index.tsx
@@ -25,7 +25,8 @@ export const PointMarkerString = ({
     wrapperStyle: css`
       box-sizing: border-box;
       background-size: cover;
-      transition: 0.5s;
+      width: 60px;
+      height: 68px;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -33,6 +34,7 @@ export const PointMarkerString = ({
 
     markerWrapperStyle: css`
       filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+      width: 100%;
     `.styles,
     maskImgWrapperStyle: css`
       position: absolute;
@@ -55,7 +57,7 @@ export const PointMarkerString = ({
     placeNameStyle: css`
       position: absolute;
       text-align: center;
-      transform: translate(30px, -100%);
+      transform: translate(0, -100%);
       white-space: nowrap;
       color: #000000;
       font-weight: 500;

--- a/components/atoms/Marker/PointMarker/index.tsx
+++ b/components/atoms/Marker/PointMarker/index.tsx
@@ -8,6 +8,7 @@ export interface MarkerProps {
   scale?: number;
   width?: number;
   height?: number;
+  placeName: string;
 }
 
 export const PointMarkerString = ({
@@ -17,23 +18,29 @@ export const PointMarkerString = ({
   width = 60,
   height = 60,
   scale = 1,
+  placeName = "",
 }: MarkerProps) => {
   const src = instaId ? `/images/${instaId}/0.jpg` : "/images/@4fbhouse/0.jpg";
-
   const componentCss = {
     wrapperStyle: css`
       box-sizing: border-box;
       background-size: cover;
-      filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
       transition: 0.5s;
-      width: 80px;
-      height: 80px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
     `.styles,
 
+    markerWrapperStyle: css`
+      filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+    `.styles,
     maskImgWrapperStyle: css`
       position: absolute;
       top: 1px;
       left: 1px;
+      width: 60px;
+      height: 68px;
+      overflow: hidden;
     `.styles,
 
     maskImgStyle: css`
@@ -44,20 +51,40 @@ export const PointMarkerString = ({
       background-position: center;
       transform: translate(-10px, -10px);
     `.styles,
+
+    placeNameStyle: css`
+      position: absolute;
+      text-align: center;
+      transform: translate(30px, -100%);
+      white-space: nowrap;
+      color: #000000;
+      font-weight: 500;
+      text-shadow: 0 0.5px white, 0.5px 0px white, -0.5px 0px white,
+        0px -0.5px white, 1px 1px 1px ${borderColor}77;
+    `.styles,
   };
 
-  const { wrapperStyle, maskImgStyle, maskImgWrapperStyle } = componentCss;
-
+  const {
+    wrapperStyle,
+    markerWrapperStyle,
+    maskImgStyle,
+    maskImgWrapperStyle,
+    placeNameStyle,
+  } = componentCss;
   return `
-<div class="mapgl-marker-animation" style="${wrapperStyle}">
-  <svg width="${width}"viewBox="0 0 60 68" fill="none"  style="position:absolute"xmlns="http://www.w3.org/2000/svg">
-    <path d="M37.8875 60.9271L30 67.5L22.6341 61.0006C21.9033 60.3558 20.9622 60 19.9876 60H4C1.79086 60 0 58.2091 0 56V4C0 1.79086 1.79086 0 4 0H56C58.2091 0 60 1.79086 60 4V56C60 58.2091 58.2091 60 56 60H40.4482C39.5125 60 38.6063 60.3281 37.8875 60.9271Z" fill="${borderColor}"/>
-  </svg>
-  <div style="${maskImgWrapperStyle} clip-path: path('M55 58H38.7862C38.0843 58 37.4047 58.246 36.8656 58.6953L33.35 61.625L29 65.25L21.6339 58.7505C21.0858 58.2669 20.38 58 19.649 58H3C1.34315 58 0 56.6569 0 55V3C0 1.34315 1.34315 0 3 0H55C56.6569 0 58 1.34315 58 3V55C58 56.6569 56.6569 58 55 58Z'); ">
-    <div style="${maskImgStyle}" ></div>
-  </div>
+
+  <div class="mapgl-marker-animation" style="${wrapperStyle}">
+    <div style="${placeNameStyle}">${placeName}</div>
+    <div style="${markerWrapperStyle}">
+      <svg width="${width}"viewBox="0 0 60 68" fill="none"  style="position:absolute"xmlns="http://www.w3.org/2000/svg">
   
-</div>
+        <path d="M37.8875 60.9271L30 67.5L22.6341 61.0006C21.9033 60.3558 20.9622 60 19.9876 60H4C1.79086 60 0 58.2091 0 56V4C0 1.79086 1.79086 0 4 0H56C58.2091 0 60 1.79086 60 4V56C60 58.2091 58.2091 60 56 60H40.4482C39.5125 60 38.6063 60.3281 37.8875 60.9271Z" fill="${borderColor}"/>
+      </svg>
+      <div style="${maskImgWrapperStyle} clip-path: path('M55 58H38.7862C38.0843 58 37.4047 58.246 36.8656 58.6953L33.35 61.625L29 65.25L21.6339 58.7505C21.0858 58.2669 20.38 58 19.649 58H3C1.34315 58 0 56.6569 0 55V3C0 1.34315 1.34315 0 3 0H55C56.6569 0 58 1.34315 58 3V55C58 56.6569 56.6569 58 55 58Z'); ">
+        <div style="${maskImgStyle}" ></div>
+      </div>
+    </div>
+  </div>
 `;
 };
 
@@ -72,3 +99,18 @@ export const PointMarker = ({
 
   return <div dangerouslySetInnerHTML={{ __html: __html }}></div>;
 };
+
+// <div class="mapgl-marker-animation" style="${wrapperStyle}">
+//   <div style="${placeNameStyle}">${placeName}</div>
+//   <div>
+//     <svg width="${width}"viewBox="0 0 60 68" fill="none"  style="position:absolute;" xmlns="http://www.w3.org/2000/svg">
+//     <defs>
+//       <pattern id="id_${src}" x="0" y="0"patternUnits="userSpaceOnUse" width="80" height="80">
+//         <image href=${src} preserveAspectRatio="none" width="100%" height="100%" />
+//       </pattern>
+//       </defs>
+//       <path d="M37.8875 60.9271L30 67.5L22.6341 61.0006C21.9033 60.3558 20.9622 60 19.9876 60H4C1.79086 60 0 58.2091 0 56V4C0 1.79086 1.79086 0 4 0H56C58.2091 0 60 1.79086 60 4V56C60 58.2091 58.2091 60 56 60H40.4482C39.5125 60 38.6063 60.3281 37.8875 60.9271Z" fill="url(#id_${src})"/>
+//     </svg>
+
+//   </div>
+// </div>

--- a/components/atoms/Marker/PointMarker/point.module.css
+++ b/components/atoms/Marker/PointMarker/point.module.css
@@ -1,13 +1,11 @@
 .mouseOver{
-    z-index:10;
-    transform-origin : 50% 100% 0;
+    transform-origin : center bottom 0;
     transform : scale(1.5);
     transition:0.2s ease;
 
 }
 .mouseOut{
-    z-index:1;
-    transform-origin : 50% 100% 0;
+    transform-origin : center bottom 0;
     transform:scale(1);
     transition:0.2s ease;
 

--- a/components/atoms/Marker/PointMarker/pointMarkerAddEvents.ts
+++ b/components/atoms/Marker/PointMarker/pointMarkerAddEvents.ts
@@ -11,8 +11,9 @@ export const AddPointMarkerEvents = (el: HTMLElement) => {
 
 function mouseOverListenerFunction(this: HTMLElement, e: Event) {
   e.preventDefault();
-  const child  = this.firstChild as Element
-  if (this.firstChild) {
+  this.style.zIndex = "10";
+  const child = this.firstElementChild as Element
+  if (this.firstElementChild) {
     child.classList.remove(mouseOut)
     child.classList.add(mouseOver)
   };
@@ -20,8 +21,9 @@ function mouseOverListenerFunction(this: HTMLElement, e: Event) {
 
 function mouseOutListenerFunction(this: HTMLElement, e: Event) {
   e.preventDefault();
-  const child  = this.firstChild as Element
-  if (this.firstChild) {
+  this.style.zIndex = "0";
+   const child  = this.firstElementChild as Element
+  if (this.firstElementChild) {
     child.classList.remove(mouseOver)
     child.classList.add(mouseOut)
   };


### PR DESCRIPTION
## 마커에 장소이름 추가
- 기존 사진으로만 보여주던 마커에 장소이름을 상단에 추가했습니다

## 마커 디테일 수정
- 장소 이름 중앙정렬을 위해 마커 element 구조를 변경하였습니다
- 마커가 scale(1.5)될 때 y축 윗쪽 방향으로만 커지게끔 마커의 anchor 위치를 바텀에 두었습니다
- 마커가 호버/ 터치됐을 때 z-index 변경 상황이 적용되지 않던 것을 수정했습니다